### PR TITLE
feat: Docker 化部署支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ npm run dev
 
 访问 **http://localhost:3000**
 
+
 ---
 
 ### 方式二：CLI 命令行
@@ -241,6 +242,24 @@ uv run vmarker shownotes input.srt
 uv run vmarker subtitle input.srt
 uv run vmarker themes  # 列出配色方案
 ```
+
+---
+
+### 方式三：Docker
+
+```bash
+docker compose up --build
+```
+
+打开 **http://localhost:3000**。
+
+**环境变量说明（最简）**：
+- 后端读取 `backend/.env`（需要 `API_KEY` 才能使用 AI 分段）。
+- 前端读取 `web/.env.local`，其中 `NEXT_PUBLIC_API_URL` 必须是浏览器可访问的地址，**本机就是 `http://localhost:8000`**。
+
+改完 `web/.env.local` 后需要重新构建前端镜像：  
+`docker compose build vmarker-web`
+
 
 #### 安装模式（全局使用）
 

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+.venv/
+.git/
+tests/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,31 @@
+FROM python:3.13-slim AS builder
+
+RUN pip install --no-cache-dir uv
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock README.md ./
+COPY src/ ./src/
+
+RUN uv sync --frozen --no-dev
+
+FROM python:3.13-slim AS runner
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ffmpeg \
+        libgomp1 && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/src /app/src
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+EXPOSE 8000
+
+CMD ["uvicorn", "vmarker.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  vmarker-api:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: vmarker-api
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    env_file:
+      - ./backend/.env
+    volumes:
+      - vmarker-temp:/tmp/vmarker
+
+  vmarker-web:
+    build:
+      context: ./web
+      dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-}
+        NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL:-}
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY:-}
+    container_name: vmarker-web
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    depends_on:
+      - vmarker-api
+
+volumes:
+  vmarker-temp:

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,5 @@
+node_modules/
+.next/
+.git/
+npm-debug.log
+yarn-error.log

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+ARG NEXT_PUBLIC_API_URL
+ARG NEXT_PUBLIC_SUPABASE_URL
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
+ENV NODE_ENV=production
+RUN \
+    if [ -z "$NEXT_PUBLIC_API_URL" ]; then unset NEXT_PUBLIC_API_URL; fi && \
+    if [ -z "$NEXT_PUBLIC_SUPABASE_URL" ]; then unset NEXT_PUBLIC_SUPABASE_URL; fi && \
+    if [ -z "$NEXT_PUBLIC_SUPABASE_ANON_KEY" ]; then unset NEXT_PUBLIC_SUPABASE_ANON_KEY; fi && \
+    npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+RUN apk add --no-cache libc6-compat
+ENV NODE_ENV=production \
+    PORT=3000
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
Closes #7

## 变更

- `docker-compose.yml`: 服务编排 (vmarker-api + vmarker-web)
- `backend/Dockerfile`: 多阶段构建，uv + ffmpeg
- `web/Dockerfile`: Next.js standalone 输出
- 相关 `.dockerignore` 配置
- `next.config.ts`: 启用 standalone 模式

## 部署

```bash
docker compose up -d
```